### PR TITLE
chore: migrate project to pnpm 10.31.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,31 +5,32 @@ https://github.com/shizuku86/Kairo
 
 After cloning, run the following command to install node_modules:
 
-- npm install
+- pnpm install
 
 After editing the lines ending with # in scripts/properties.ts appropriately and resolving errors,  
 execute the following command in the terminal:
 
-- npm run build
+- pnpm run build
 
 When this command is executed, the following operations will be performed:
 
 - manifest.json is automatically generated in BP/ and RP/ from the information in properties
-- TypeScript files in scripts/ are built as JavaScript into BP/scripts
+- TypeScript files in scripts/ are bundled with esbuild as JavaScript into BP/scripts
 - The pack_icon.png at the project root is copied into both BP/ and RP/
 - The completed BP/ and RP/ are copied into Minecraft’s development folder
 
 ## Requirements
 
-- Node.js (for development and TypeScript build)
+- Node.js (for development and TypeScript + esbuild build)
+- pnpm 10.31.0
 
 ## Setup && Build
 
 1. Install dependencies:
     ```bash
-    npm install
+    pnpm install
     ```
 2. Deploy
     ```bash
-    npm run build
+    pnpm run build
     ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "type": "module",
     "scripts": {
-        "build": "node src/generate-event-imports.js && rimraf BP/scripts && tsc --noEmit && node build.mjs && npm run deploy",
+        "build": "node src/generate-event-imports.js && rimraf BP/scripts && tsc --noEmit && node build.mjs && pnpm run deploy",
         "deploy": "node src/deploy.js"
     },
     "repository": {
@@ -27,5 +27,6 @@
         "prettier": "3.6.2",
         "rimraf": "^6.0.1",
         "typescript": "^5.9.2"
-    }
+    },
+    "packageManager": "pnpm@10.31.0"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         // For nodejs:
         // "lib": ["esnext"],
         // "types": ["node"],
-        // and npm install -D @types/node
+        // and pnpm add -D @types/node
 
         // Other Outputs
         "sourceMap": false,


### PR DESCRIPTION
### Motivation

- Standardize the repository on `pnpm` as the package manager and document `pnpm@10.31.0` as the required version.  
- Ensure the build flow is fully `pnpm`-based and clarify that TypeScript outputs are bundled with `esbuild`.  
- Update local developer guidance to use `pnpm` instead of `npm` for installing dev dependencies.

### Description

- Updated `package.json` `build` script to call `pnpm run deploy` instead of `npm run deploy`.  
- Added `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf9897ce88333ac85cec158944854)